### PR TITLE
Test for module name rules in FSI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -478,3 +478,4 @@ $RECYCLE.BIN/
 
 test/
 test2/
+/test-aot

--- a/FSharpPacker.Tests/Samples/lowercase-script.fsx
+++ b/FSharpPacker.Tests/Samples/lowercase-script.fsx
@@ -1,0 +1,3 @@
+#load "testscript.fsx"
+open Testscript
+testScript()

--- a/FSharpPacker.Tests/Samples/testscript.fsx
+++ b/FSharpPacker.Tests/Samples/testscript.fsx
@@ -1,0 +1,2 @@
+open System
+let testScript() = Console.WriteLine 1

--- a/FSharpPacker.Tests/UnitTest1.cs
+++ b/FSharpPacker.Tests/UnitTest1.cs
@@ -127,11 +127,11 @@ public class UnitTest1
 
         preprocessor.Process();
 
-        // we expect module name of test in lowercase should be in pascal case
-        Assert.AreEqual("module Testscript" + Environment.NewLine + "open System" + Environment.NewLine + "let testScript() = Console.WriteLine 1", preprocessor.GetSources()[0].ReadProducedFile());
-        // we expect module name of test in kebabcase should be escaped correctly
-        Assert.AreEqual("module ``lowercase-script``" + Environment.NewLine + "open Testscript" + Environment.NewLine + "testScript()", preprocessor.GetSources()[1].ReadProducedFile());
         var sources = preprocessor.GetSources();
         Assert.AreEqual(2, sources.Count);
+        // we expect module name of test in lowercase should be in pascal case
+        Assert.AreEqual("module Testscript" + Environment.NewLine + "open System" + Environment.NewLine + "let testScript() = Console.WriteLine 1" + Environment.NewLine, sources[0].ReadProducedFile());
+        // we expect module name of test in kebabcase should be escaped correctly
+        Assert.AreEqual("module ``lowercase-script``" + Environment.NewLine + "open Testscript" + Environment.NewLine + "testScript()" + Environment.NewLine, sources[1].ReadProducedFile());
     }
 }

--- a/FSharpPacker.Tests/UnitTest1.cs
+++ b/FSharpPacker.Tests/UnitTest1.cs
@@ -116,4 +116,22 @@ public class UnitTest1
         var sources = preprocessor.GetSources();
         Assert.AreEqual(2, sources.Count);
     }
+    
+    [TestMethod]
+    public void LowercaseScriptWithDashesInName()
+    {
+        var sourceFile = "Samples/lowercase-script.fsx";
+        var preprocessor = new FsxPreprocessor()
+            .WithBasePath("HomeDirectory");
+        preprocessor.AddSource(sourceFile);
+
+        preprocessor.Process();
+
+        // we expect module name of test in lowercase should be in pascal case
+        Assert.AreEqual("module Testscript" + Environment.NewLine + "open System" + Environment.NewLine + "let testScript() = Console.WriteLine 1", preprocessor.GetSources()[0].ReadProducedFile());
+        // we expect module name of test in kebabcase should be escaped correctly
+        Assert.AreEqual("module ``lowercase-script``" + Environment.NewLine + "open Testscript" + Environment.NewLine + "testScript()", preprocessor.GetSources()[1].ReadProducedFile());
+        var sources = preprocessor.GetSources();
+        Assert.AreEqual(2, sources.Count);
+    }
 }

--- a/FSharpPacker.sln
+++ b/FSharpPacker.sln
@@ -1,8 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.32912.340
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FSharpPacker", "FSharpPacker\FSharpPacker.csproj", "{95C8A061-7641-4DC7-BBAA-8BB9E3C11D58}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FSharpPacker.Tests", "FSharpPacker.Tests\FSharpPacker.Tests.csproj", "{0F8BDD37-4B22-43C3-910C-B3A3DDABEDAC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{534D7B89-96BA-42F3-8AAE-8051C8A7504D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+		nuget.config = nuget.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +27,11 @@ Global
 		{0F8BDD37-4B22-43C3-910C-B3A3DDABEDAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F8BDD37-4B22-43C3-910C-B3A3DDABEDAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F8BDD37-4B22-43C3-910C-B3A3DDABEDAC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {53A28840-8B55-4996-B5F6-6886AC86A8CC}
 	EndGlobalSection
 EndGlobal

--- a/FSharpPacker/FsxPreprocessor.cs
+++ b/FSharpPacker/FsxPreprocessor.cs
@@ -37,7 +37,7 @@ public class FsxPreprocessor
 
     private void ProcessFile(SourceFile sourceFile)
     {
-        sourceFile.WriteLine($"module {Path.GetFileNameWithoutExtension(sourceFile.FileName)}");
+        sourceFile.WriteLine($"module {GetModuleName(sourceFile)}");
         foreach (var line in sourceFile.ReadContent())
         {
             var normalizedLine = Regex.Replace(line, "\\s+\\#\\s+", "#");
@@ -52,7 +52,7 @@ public class FsxPreprocessor
                         var packageParts = normalizedReference.Substring("nuget:".Length).Split(',');
                         var name = packageParts[0].Trim();
                         var version = packageParts.ElementAtOrDefault(1)?.Trim() ?? "*";
-                        this.packageReferences.Add(new (name, version));
+                        this.packageReferences.Add(new(name, version));
                     }
                     else
                     {
@@ -85,6 +85,22 @@ public class FsxPreprocessor
                 sourceFile.WriteLine(line);
             }
         }
+    }
+
+    private static string GetModuleName(SourceFile sourceFile)
+    {
+        string fileName = Path.GetFileNameWithoutExtension(sourceFile.FileName);
+        if (!Regex.IsMatch(fileName, "^[_a-zA-Z][_a-zA-Z0-9]{0,30}$"))
+        {
+            return "``" + fileName + "``";
+        }
+
+        if (char.IsLower(fileName[0]))
+        {
+            return char.ToUpper(fileName[0]) + fileName.Substring(1);
+        }
+
+        return fileName;
     }
 
     private string Unquote(string data)

--- a/FSharpPacker/Program.cs
+++ b/FSharpPacker/Program.cs
@@ -52,6 +52,8 @@ var projectContent = @$"<Project Sdk=""Microsoft.NET.Sdk"">
 </Project>
 ";
 File.WriteAllText(tempProject, projectContent);
-Console.WriteLine(tempProject);
-var process = Process.Start("dotnet", (new [] { "publish", tempProject }).Union(args.Skip(1)));
+Console.WriteLine($"Compiling generated file {tempProject}");
+var commandLineArguments = (new[] { "publish", tempProject }).Union(args.Skip(1));
+Console.WriteLine($"Running dotnet {string.Join(" ", commandLineArguments)}");
+var process = Process.Start("dotnet", commandLineArguments);
 process.WaitForExit();

--- a/FSharpPacker/SourceFile.cs
+++ b/FSharpPacker/SourceFile.cs
@@ -22,7 +22,7 @@ public class SourceFile
 
     public string FileName { get; }
 
-    public string ReadLine()
+    public string? ReadLine()
     {
         return this.reader.ReadLine();
     }

--- a/README.md
+++ b/README.md
@@ -15,5 +15,10 @@ I have install broken .NET 7.0. Change csproj and Program.cs and that's it.
 For example:
 ```
 cd FSharpPacker
-dotnet run ..\FSharpPacker.Tests\Samples\LoadFile.fsx --self-contained -o test2
+dotnet run --project FSharpPacker FSharpPacker.Tests\Samples\LoadFile.fsx --self-contained -o test
+```
+
+for AOT build
+```
+dotnet run --project FSharpPacker FSharpPacker.Tests\Samples\LoadFile.fsx --self-contained -o test-aot -- -r win-x64 /p:PublishAot=true
 ```

--- a/nuget.config
+++ b/nuget.config
@@ -3,8 +3,8 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <!--<add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />-->
   </packageSources>
 </configuration>


### PR DESCRIPTION
- Camel casing rules validation
- Escape for non-identifier filenames